### PR TITLE
src/lib: Default to WindowUpdateMode::OnRead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.10.0 [unreleased]
+
+- Default to `WindowUpdateMode::OnRead`, thus enabling full Yamux flow-control,
+  exercising back pressure on senders, preventing stream resets due to reaching
+  the buffer limit.
+
+  See the [`WindowUpdateMode` documentation] for details, especially the section
+  on deadlocking when sending data larger than the receivers window.
+
+  [`WindowUpdateMode` documentation]: https://docs.rs/yamux/0.9.0/yamux/enum.WindowUpdateMode.html
+
 # 0.9.0
 
 - Force-split larger frames, for better interleaving of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub enum WindowUpdateMode {
 /// - receive window = 256 KiB
 /// - max. buffer size (per stream) = 1 MiB
 /// - max. number of streams = 8192
-/// - window update mode = on receive
+/// - window update mode = on read
 /// - read after close = true
 /// - split send size = 16 KiB
 #[derive(Debug, Clone)]
@@ -109,7 +109,7 @@ impl Default for Config {
             receive_window: DEFAULT_CREDIT,
             max_buffer_size: 1024 * 1024,
             max_num_streams: 8192,
-            window_update_mode: WindowUpdateMode::OnReceive,
+            window_update_mode: WindowUpdateMode::OnRead,
             read_after_close: true,
             split_send_size: DEFAULT_SPLIT_SEND_SIZE
         }


### PR DESCRIPTION
Default to `WindowUpdateMode::OnRead`, thus enabling full Yamux
flow-control, exercising back pressure on senders, preventing stream
resets due to reaching the buffer limit.

See the [`WindowUpdateMode` documentation] for details, especially the
section on deadlocking when sending data larger than the receivers
window.

[`WindowUpdateMode` documentation]: https://docs.rs/yamux/0.9.0/yamux/enum.WindowUpdateMode.html

This would prevent surprises like https://github.com/libp2p/rust-libp2p/issues/2089.