### PR TITLE
CHANGELOG: Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.0 [unreleased]
+# 0.10.0
 
 - Default to `WindowUpdateMode::OnRead`, thus enabling full Yamux flow-control,
   exercising back pressure on senders, preventing stream resets due to reaching


### PR DESCRIPTION
Not a large release, only https://github.com/libp2p/rust-yamux/pull/120.

Let me know in case anything else should be included.