### PR TITLE
prevent receive gap

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -632,10 +632,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                     }
                     Action::Reset(f) => {
                         log::trace!("{}/{}: sending reset", self.id, f.header().stream_id());
+                        // prevent reception of further frames, since we already rejected data
+                        self.streams.remove(&f.header().stream_id());
                         self.socket.feed(f.into()).await.or(Err(ConnectionError::Closed))?
                     }
                     Action::Terminate(f) => {
                         log::trace!("{}: sending term", self.id);
+                        // prevent reception of further frames, since we already rejected data
+                        self.streams.remove(&f.header().stream_id());
                         self.socket.feed(f.into()).await.or(Err(ConnectionError::Closed))?
                     }
                 }


### PR DESCRIPTION
When testing with a high-volume long-running substream, I found that a reset caused by exceeding the `max_buffer_size` led to subsequent reception of follow-up frames.
This is a rare occurrence, I was not able to write a test case for this: my assumption is that one frame triggers the error, the reset is sent, but data are in flight, and before the next frame is passed to `on_data` the client has already consumed a few bytes, freeing up space.
I’m not intimitately familiar with yamux, so please take this PR with a grain of salt, it may not be the right way of fixing the issue.
