### PR TITLE
Fix connection flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 - Update `parking_lot` dependency. See [PR 126].
 
+- Flush socket while waiting for next frame. See [PR 130].
+
 [PR 126]: https://github.com/libp2p/rust-yamux/pull/126
+[PR 130]: https://github.com/libp2p/rust-yamux/pull/130
 
 # 0.10.0
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -431,7 +431,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 num_terminated += 1;
                 Either::Left(future::pending())
             } else {
-                // poll socket for next incoming frame, but also make sure any pending writes are properly flushed
+                // Poll socket for next incoming frame, but also make sure any pending writes are properly flushed.
                 let socket = &mut self.socket;
                 let next_frame = future::poll_fn(move |cx| {
                     if let Poll::Ready(res) = socket.poll_next_unpin(cx) {


### PR DESCRIPTION
See the full conversation here: https://github.com/libp2p/rust-libp2p/issues/2461

The bump to Yamux 0.10 in libp2p broke the wasm-ext transport (used for WebSocket transport in WebAssembly). It turns out that the wasm-ext implementation makes it more prone to yield a `Pending` on a `poll_next` (see [this](https://github.com/libp2p/rust-libp2p/blob/96dbfcd1ade6de5b4ae623f59fb0d67b2916576a/transports/wasm-ext/src/lib.rs#L485)). When used in conjunction with Noise, a frame may get buffered and only written to the underlying I/O stream when flushing it (see [this](https://github.com/libp2p/rust-libp2p/blob/b79fd02f0bdde07f437c691e278a16cf9024036a/transports/noise/src/io.rs#L138)) 

In https://github.com/libp2p/rust-yamux/pull/112, flushing is no longer awaited, but instead, is called at each iteration of the `next` loop in `Connection` (see [this](https://github.com/libp2p/rust-yamux/blob/9bdebeed794e6a8498db71b50f6d543f4f1bf3c2/src/connection.rs#L498)). Unfortunately, when using wasm-ext with Noise, frames may never get written until the next iteration is triggered by another event (incoming frame or stream/control events).

As discussed in libp2p's issue, a fix is to make sure that flushing the I/O stream gets progressed in the main loop. I also think that `flush_nowait` is not required anymore since flushing is now actively done in the loop. 