### PR TITLE
*: Prepare v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.1-rc.1 [2022-02-25]
+# 0.10.1
 
 - Update `parking_lot` dependency. See [PR 126].
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.10.1-rc.1"
+version = "0.10.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
Promotes `v0.10.1-rc.1` to `v0.10.1` after testing via https://github.com/libp2p/rust-libp2p/pull/2539.