### PR TITLE
src/error: Add `From<ConnectionError> for io::Error` implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -95,23 +95,3 @@ impl From<futures::channel::oneshot::Canceled> for ConnectionError {
         ConnectionError::Closed
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn connection_error_can_be_question_marked_to_io_error() {
-        returns_io_error().expect_err("to fail");
-    }
-
-    fn returns_io_error() -> std::io::Result<()> {
-        always_err()?;
-
-        Ok(())
-    }
-
-    fn always_err() -> Result<(), ConnectionError> {
-        Err(ConnectionError::Closed)
-    }
-}


### PR DESCRIPTION
This allows the use of `?` in functions that return `io::Error`.
