### PR TITLE
src/connection: Process command or socket result immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.10.2
+
+- Process command or socket result immediately and thereby no longer accessing
+  the socket after it returned an error. See [PR 138] for details.
+
+[PR 138]: https://github.com/libp2p/rust-yamux/pull/138
+
 # 0.10.1
 
 - Update `parking_lot` dependency. See [PR 126].

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
> The `frame` future might be _ready_ with an `Error` from the underlying
socket (i.e. here `libp2p-websocket`). Though given that the result of the
`control_command` `Future` is handled first, `on_control_command` is called
despite `frame` having returned an `Error`. `on_control_command` itself may try
to write to the underlying socket, which will panic given that the socket
returned an error earlier via the `frame` `Future`.

With this patch, once any of `next_stream_command`, `next_control_command` or
`next_frame` `Future` is ready, the result is processed right away, without
additionally polling the remaining pending `Future`s, thus surfacing errors as
early as possible.

See https://github.com/libp2p/rust-libp2p/issues/2598 for details.

@elenaf9 @thomaseizinger could either of you do me a favor and take a look here? Happy to expand on the pull request description in case more context is needed.