### PR TITLE
fix: Remove dead link to README.md

### DIFF
--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -7,7 +7,6 @@ description = "Multiplexer over reliable, ordered connections"
 keywords = ["network", "protocol"]
 categories = ["network-programming"]
 repository = "https://github.com/paritytech/yamux"
-readme = "README.md"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Release fails with the below otherwise:

```
error: failed to read `readme` file for package `yamux v0.11.0 (/home/xxx/rust-yamux/yamux)`
```