### PR TITLE
chore: prepare v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.11.1
+
+- Avoid race condition between pending frames and closing stream.
+  See [PR 156].
+  
+[PR 156]: https://github.com/libp2p/rust-yamux/pull/156
+
 # 0.11.0
 
 - Remove `Connection::control` in favor of `Control::new`.

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
@thomaseizinger with https://github.com/libp2p/rust-yamux/pull/156 merged, what do you think of a new release?

This will allow us to proceed with https://github.com/libp2p/rust-libp2p/pull/3013. We can merge and release https://github.com/libp2p/rust-yamux/pull/153 as a patch release and https://github.com/libp2p/rust-yamux/issues/154 with the next breaking release.