### PR TITLE
Allow to configure the maximum size for the frame channel between one connection and one of its stream.

### DIFF
--- a/yamux/src/connection.rs
+++ b/yamux/src/connection.rs
@@ -876,7 +876,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     fn make_new_stream(&mut self, id: StreamId, window: u32, credit: u32) -> Stream {
         let config = self.config.clone();
 
-        let (sender, receiver) = mpsc::channel(10); // 10 is an arbitrary number.
+        let (sender, receiver) = mpsc::channel(config.max_stream_backlog);
         self.stream_receivers.push(TaggedStream::new(id, receiver));
         if let Some(waker) = self.no_streams_waker.take() {
             waker.wake();

--- a/yamux/src/lib.rs
+++ b/yamux/src/lib.rs
@@ -50,6 +50,9 @@ pub type Result<T> = std::result::Result<T, ConnectionError>;
 /// actual upper bound is this value + number of clones.
 const MAX_COMMAND_BACKLOG: usize = 32;
 
+/// Arbitrary limit of our per stream channels.
+const MAX_STREAM_BACKLOG: usize = 10;
+
 /// Default maximum number of bytes a Yamux data frame might carry as its
 /// payload when being send. Larger Payloads will be split.
 ///
@@ -103,6 +106,7 @@ pub enum WindowUpdateMode {
 /// - window update mode = on read
 /// - read after close = true
 /// - split send size = 16 KiB
+/// - max. stream backlog = 10 frames
 #[derive(Debug, Clone)]
 pub struct Config {
     receive_window: u32,
@@ -111,6 +115,7 @@ pub struct Config {
     window_update_mode: WindowUpdateMode,
     read_after_close: bool,
     split_send_size: usize,
+    max_stream_backlog: usize,
 }
 
 impl Default for Config {
@@ -122,6 +127,7 @@ impl Default for Config {
             window_update_mode: WindowUpdateMode::OnRead,
             read_after_close: true,
             split_send_size: DEFAULT_SPLIT_SEND_SIZE,
+            max_stream_backlog: MAX_STREAM_BACKLOG,
         }
     }
 }
@@ -167,6 +173,12 @@ impl Config {
     /// than the configured max. will be split.
     pub fn set_split_send_size(&mut self, n: usize) -> &mut Self {
         self.split_send_size = n;
+        self
+    }
+
+    /// Set the max. stream channel size used when sending frames.
+    pub fn set_max_stream_backlog(&mut self, n: usize) -> &mut Self {
+        self.max_stream_backlog = n;
         self
     }
 }


### PR DESCRIPTION
While doing some benchmarks using iperf3 on a network client / server application using Yamux + Tokio TcpStream + rustls we noticed that the mpsc between a Connection and one of its Stream was filling too fast leading to lower bandwidth.

With the default hard-coded value (10 packets) with the client and server application running inside two dockers on the same laptop, we measured 315 Mbits/sec. With an increased value of 16*1024 packets, we measured 426 Mbits/sec.

This PR adds an API that allow setting this value in YamuxConfig and leave the default value as is.
