### PR TITLE
chore: prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.0 - unreleased
+# 0.12.0
 
 - Remove `Control` and `ControlledConnection`.
   Users have to move to the `poll_` functions of `Connection`.
@@ -11,7 +11,7 @@
 
 - Avoid race condition between pending frames and closing stream.
   See [PR 156].
-  
+
 [PR 156]: https://github.com/libp2p/rust-yamux/pull/156
 
 # 0.11.0


### PR DESCRIPTION
I suggest we release `v0.12.0` right away. Most important change is https://github.com/libp2p/rust-yamux/pull/167.

@thomaseizinger any objections?

@aschran is that good enough for you, or would you need a `v0.11.2` patch release?