### PR TITLE
chore: remove `WindowUpdateMode::OnReceive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.13.0
+
+- Remove `WindowUpdateMode`.
+  Behavior will always be `WindowUpdateMode::OnRead`, thus enabling flow-control and enforcing backpressure.
+  See [PR 178](https://github.com/libp2p/rust-yamux/pull/178).
+
 # 0.12.0
 
 - Remove `Control` and `ControlledConnection`.

--- a/test-harness/benches/concurrent.rs
+++ b/test-harness/benches/concurrent.rs
@@ -74,12 +74,6 @@ fn concurrent(c: &mut Criterion) {
     group.finish();
 }
 
-fn config() -> Config {
-    let mut c = Config::default();
-    c.set_window_update_mode(yamux::WindowUpdateMode::OnRead);
-    c
-}
-
 async fn oneway(
     nstreams: usize,
     nmessages: usize,
@@ -87,8 +81,8 @@ async fn oneway(
     server: Endpoint,
     client: Endpoint,
 ) {
-    let server = Connection::new(server, config(), Mode::Server);
-    let client = Connection::new(client, config(), Mode::Client);
+    let server = Connection::new(server, Config::default(), Mode::Server);
+    let client = Connection::new(client, Config::default(), Mode::Client);
 
     task::spawn(dev_null_server(server));
 

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -13,8 +13,8 @@ use std::{fmt, io, mem};
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::task;
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+use yamux::Config;
 use yamux::ConnectionError;
-use yamux::{Config, WindowUpdateMode};
 use yamux::{Connection, Mode};
 
 pub async fn connected_peers(
@@ -448,11 +448,6 @@ pub struct TestConfig(pub Config);
 impl Arbitrary for TestConfig {
     fn arbitrary(g: &mut Gen) -> Self {
         let mut c = Config::default();
-        c.set_window_update_mode(if bool::arbitrary(g) {
-            WindowUpdateMode::OnRead
-        } else {
-            WindowUpdateMode::OnReceive
-        });
         c.set_read_after_close(Arbitrary::arbitrary(g));
         c.set_receive_window(256 * 1024 + u32::arbitrary(g) % (768 * 1024));
         TestConfig(c)

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"
@@ -19,4 +19,5 @@ static_assertions = "1"
 pin-project = "1.1.0"
 
 [dev-dependencies]
+futures = { version = "0.3.12", default-features = false, features = ["executor"] }
 quickcheck = "1.0"

--- a/yamux/src/lib.rs
+++ b/yamux/src/lib.rs
@@ -63,32 +63,6 @@ const MAX_ACK_BACKLOG: usize = 256;
 /// https://github.com/paritytech/yamux/issues/100.
 const DEFAULT_SPLIT_SEND_SIZE: usize = 16 * 1024;
 
-/// Specifies when window update frames are sent.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum WindowUpdateMode {
-    /// Send window updates as soon as a [`Stream`]'s receive window drops to 0.
-    ///
-    /// This ensures that the sender can resume sending more data as soon as possible
-    /// but a slow reader on the receiving side may be overwhelmed, i.e. it accumulates
-    /// data in its buffer which may reach its limit (see `set_max_buffer_size`).
-    /// In this mode, window updates merely prevent head of line blocking but do not
-    /// effectively exercise back pressure on senders.
-    OnReceive,
-
-    /// Send window updates only when data is read on the receiving end.
-    ///
-    /// This ensures that senders do not overwhelm receivers and keeps buffer usage
-    /// low. However, depending on the protocol, there is a risk of deadlock, namely
-    /// if both endpoints want to send data larger than the receivers window and they
-    /// do not read before finishing their writes. Use this mode only if you are sure
-    /// that this will never happen, i.e. if
-    ///
-    /// - Endpoints *A* and *B* never write at the same time, *or*
-    /// - Endpoints *A* and *B* write at most *n* frames concurrently such that the sum
-    ///   of the frame lengths is less or equal to the available credit of *A* and *B*
-    ///   respectively.
-    OnRead,
-}
 
 /// Yamux configuration.
 ///
@@ -105,7 +79,6 @@ pub struct Config {
     receive_window: u32,
     max_buffer_size: usize,
     max_num_streams: usize,
-    window_update_mode: WindowUpdateMode,
     read_after_close: bool,
     split_send_size: usize,
 }
@@ -116,7 +89,6 @@ impl Default for Config {
             receive_window: DEFAULT_CREDIT,
             max_buffer_size: 1024 * 1024,
             max_num_streams: 8192,
-            window_update_mode: WindowUpdateMode::OnRead,
             read_after_close: true,
             split_send_size: DEFAULT_SPLIT_SEND_SIZE,
         }
@@ -144,12 +116,6 @@ impl Config {
     /// Set the max. number of streams.
     pub fn set_max_num_streams(&mut self, n: usize) -> &mut Self {
         self.max_num_streams = n;
-        self
-    }
-
-    /// Set the window update mode to use.
-    pub fn set_window_update_mode(&mut self, m: WindowUpdateMode) -> &mut Self {
-        self.window_update_mode = m;
         self
     }
 


### PR DESCRIPTION
Follow up to previous deprecation https://github.com/libp2p/rust-yamux/pull/177.

Fixes https://github.com/libp2p/rust-yamux/issues/175.