### PR TITLE
chore: move to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["yamux", "test-harness"]
+resolver = "2"

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-harness"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -7,7 +7,7 @@ description = "Multiplexer over reliable, ordered connections"
 keywords = ["network", "protocol"]
 categories = ["network-programming"]
 repository = "https://github.com/paritytech/yamux"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 futures = { version = "0.3.12", default-features = false, features = ["std"] }


### PR DESCRIPTION
If I understand correctly, this is a local change only, and thus does not require a changelog entry. Am I correct @thomaseizinger? Any objections?