### PR TITLE
Implement Connection::get_ref to retrieve a reference to the socket

### DIFF
--- a/yamux/src/connection/closing.rs
+++ b/yamux/src/connection/closing.rs
@@ -36,6 +36,11 @@ where
             socket,
         }
     }
+
+    /// Retrieve a reference to the socket.
+    pub(crate) fn get_ref(&self) -> &T {
+        self.socket.get_ref().get_ref()
+    }
 }
 
 impl<T> Future for Closing<T>

--- a/yamux/src/frame/io.rs
+++ b/yamux/src/frame/io.rs
@@ -45,6 +45,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
             write_state: WriteState::Init,
         }
     }
+
+    /// Retrieve a reference reference to the socket.
+    pub(crate) fn get_ref(&self) -> &T {
+        &self.io
+    }
 }
 
 /// The stages of writing a new `Frame`.


### PR DESCRIPTION
This lets users of `Connection` immutably access the socket they provided.