### PR TITLE
fix: avoid possible poisoned connection when closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.5
+
+- Fix possible poisoned connection when closing. See [PR 199](https://github.com/libp2p/rust-yamux/pull/199).
+
 # 0.13.4
 
 - Fix sending pending frames after closing. See [PR 194](https://github.com/libp2p/rust-yamux/pull/194).

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
The connection state can become `Poisoned` if poll_close returns an error. Although an implementer should never poll again after an error, the connection state should also never be `Poisoned` (`unreachable!`).