### PR TITLE
yamux/frame: Ensure frame io does not panic on invalid write results

### DIFF
--- a/yamux/src/frame/io.rs
+++ b/yamux/src/frame/io.rs
@@ -101,6 +101,17 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sink<Frame<()>> for Io<T> {
                             return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
                         }
                         *offset += n;
+
+                        if *offset > header.len() {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                format!(
+                                    "Writer header returned invalid write count n={n}: {offset} > {} ",
+                                    header.len(),
+                                ),
+                            )));
+                        }
+
                         if *offset == header.len() {
                             if !buffer.is_empty() {
                                 let buffer = std::mem::take(buffer);
@@ -122,6 +133,17 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sink<Frame<()>> for Io<T> {
                             return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
                         }
                         *offset += n;
+
+                        if *offset > buffer.len() {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                format!(
+                                    "Writer body returned invalid write count n={n}: {offset} > {} ",
+                                    buffer.len(),
+                                ),
+                            )));
+                        }
+
                         if *offset == buffer.len() {
                             this.write_state = WriteState::Init;
                         }


### PR DESCRIPTION
This PR ensures that the Sink implementation of the yamux-frame does not panic when the returned number of bytes from a write operation is bigger than the header size.

We have noticed this behavior on live chains in polkadot as reported by:
- https://github.com/paritytech/polkadot-sdk/issues/9169

The issue shows that in the `WriteState::Header` state, the inner IO socket returned an offset bigger than the length of the header during the `poll_write` operation. This then leads to incrementing the offset past the header capacity in a following call. While at it, have ensured that the `WriteState::Body` state is safe from panics as well.

It is unclear at the moment of writing if the issue comes from: higher levels of the yamux crate, websocket tokio tungstenite (unconfirmed if this affects only the websocket or not), or the buffering of sockets from litep2p.

However, considering this is a one-off issue and we have not seen it in Kusama for the past 6+months of testing, terminating the connection in these cases seems like a sensible thing to do.

Would love to get your thoughts on this @jxs @elenaf9 🙏 
