### PR TITLE
use % 2 == 0 instead of is_multiple_of to check parity,

### DIFF
--- a/yamux/src/frame/header.rs
+++ b/yamux/src/frame/header.rs
@@ -297,8 +297,10 @@ impl StreamId {
         StreamId(val)
     }
 
+    // TODO: remove and use is multiple_of() on the next minor release.
+    #[allow(clippy::manual_is_multiple_of)]
     pub fn is_server(self) -> bool {
-        self.0.is_multiple_of(2)
+        self.0 % 2 == 0
     }
 
     pub fn is_client(self) -> bool {


### PR DESCRIPTION
to support older Rust versions

fixes #207
