### PR TITLE
feat: add configurable yamux close timeout for unread remote peers

### DIFF
--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.9.0"
 static_assertions = "1"
 pin-project = "1.1.0"
 web-time = "1.1.0"
+futures-timer = "3.0.3"
 
 [dev-dependencies]
 futures = { version = "0.3.12", default-features = false, features = ["executor"] }

--- a/yamux/src/connection.rs
+++ b/yamux/src/connection.rs
@@ -381,7 +381,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
             .into_iter()
             .chain(self.pending_write_frame)
             .collect::<VecDeque<Frame<()>>>();
-        Closing::new(self.stream_receivers, pending_frames, self.socket)
+        Closing::new(
+            self.stream_receivers,
+            pending_frames,
+            self.socket,
+            self.config.connection_close_timeout,
+        )
     }
 
     /// Cleanup all our resources.

--- a/yamux/src/frame/io.rs
+++ b/yamux/src/frame/io.rs
@@ -82,6 +82,16 @@ impl fmt::Debug for WriteState {
     }
 }
 
+impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
+    pub(crate) fn poll_force_close(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let this = Pin::into_inner(self);
+        Pin::new(&mut this.io).poll_close(cx)
+    }
+}
+
 impl<T: AsyncRead + AsyncWrite + Unpin> Sink<Frame<()>> for Io<T> {
     type Error = io::Error;
 


### PR DESCRIPTION
This introduces a configurable timeout for `yamux` connection shutdown, so `poll_close` can complete even when the remote peer stops reading from the underlying transport.
When the timeout elapses during yamux close, the implementation stops waiting on yamux-level frame draining and force-closes at the yamux state-machine level.

In backpressured scenarios (e.g. remote stops reading), graceful yamux shutdown may otherwise wait indefinitely while trying to flush pending frames. This change gives users a bounded close path for those situations.

**Important**: this timeout only affects yamux protocol-level shutdown behavior.  
It does **not** replace transport/socket-level close semantics. For TCP-level behavior (e.g. FIN/RST/linger behavior), users should still configure socket options such as `SO_LINGER` as appropriate for their environment.