### PR TITLE
fix: TooManyStreams non-fatal, keep connection alive at capacity

### DIFF
--- a/test-harness/tests/poll_api.rs
+++ b/test-harness/tests/poll_api.rs
@@ -96,11 +96,21 @@ fn prop_max_streams() {
 
             let client = OpenStreamsClient::new(client, max_streams);
 
-            let (client, streams) = client.await?;
+            let (mut client, streams) = client.await?;
             assert_eq!(streams.len(), max_streams);
 
-            let open_result = OpenStreamsClient::new(client, 1).await;
-            Ok(matches!(open_result, Err(ConnectionError::TooManyStreams)))
+            // At capacity: TooManyStreams is returned but connection stays alive.
+            let result = future::poll_fn(|cx| client.poll_new_outbound(cx)).now_or_never();
+            assert!(matches!(
+                result,
+                Some(Err(ConnectionError::TooManyStreams))
+            ));
+
+            drop(streams);
+
+            // Connection still alive — can open new streams.
+            let (_, new_streams) = OpenStreamsClient::new(client, 1).await?;
+            Ok(new_streams.len() == 1)
         })
     }
     QuickCheck::new().tests(7).quickcheck(prop as fn(_) -> _)

--- a/yamux/src/connection.rs
+++ b/yamux/src/connection.rs
@@ -103,6 +103,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                         self.inner = ConnectionState::Active(active);
                         return Poll::Pending;
                     }
+                    Poll::Ready(Err(ConnectionError::TooManyStreams)) => {
+                        // Capacity limit is transient — keep the connection alive
+                        // so existing streams continue working. The caller can
+                        // retry on another connection.
+                        self.inner = ConnectionState::Active(active);
+                        return Poll::Ready(Err(ConnectionError::TooManyStreams));
+                    }
                     Poll::Ready(Err(e)) => {
                         self.inner = ConnectionState::Cleanup(active.cleanup(e));
                         continue;
@@ -487,7 +494,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
 
     fn poll_new_outbound(&mut self, cx: &mut Context<'_>) -> Poll<Result<Stream>> {
         if self.streams.len() >= self.config.max_num_streams {
-            log::error!("{}: maximum number of streams reached", self.id);
+            log::debug!("{}: maximum number of streams reached", self.id);
             return Poll::Ready(Err(ConnectionError::TooManyStreams));
         }
 


### PR DESCRIPTION
TooManyStreams previously triggered Cleanup -> drop_all_streams(), killing all existing streams on the connection. When one mux connection died and load shifted, other connections hitting the N limit would cascade.

- poll_new_outbound: return Err(TooManyStreams) while staying in Active state, so existing streams continue working
- log level: error -> debug (now normal flow control, not a fatal event)
- test: verify connection survives TooManyStreams and accepts new streams after capacity is freed