### PR TITLE
fix typo: occured -> occurred

### DIFF
--- a/yamux/src/error.rs
+++ b/yamux/src/error.rs
@@ -14,7 +14,7 @@ use crate::frame::FrameDecodeError;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum ConnectionError {
-    /// An underlying I/O error occured.
+    /// An underlying I/O error occurred.
     Io(std::io::Error),
     /// Decoding a Yamux message frame failed.
     Decode(FrameDecodeError),


### PR DESCRIPTION
Fix doc-comment typo 'occured' in yamux/src/error.rs.