### PR TITLE
feat: replace rand-based IDs and nonce with atomic counters

### DIFF
--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -14,7 +14,6 @@ futures = { version = "0.3.12", default-features = false, features = ["std", "ex
 log = "0.4.8"
 nohash-hasher = "0.2"
 parking_lot = "0.12"
-rand = "0.9.0"
 static_assertions = "1"
 pin-project = "1.1.0"
 web-time = "1.1.0"
@@ -22,3 +21,4 @@ web-time = "1.1.0"
 [dev-dependencies]
 futures = { version = "0.3.12", default-features = false, features = ["executor"] }
 quickcheck = { package = "quickcheck-ext", path = "../quickcheck-ext" }
+rand = "0.9.0"

--- a/yamux/src/connection.rs
+++ b/yamux/src/connection.rs
@@ -17,6 +17,8 @@ mod closing;
 mod rtt;
 mod stream;
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use crate::tagged_stream::TaggedStream;
 use crate::{
     error::ConnectionError,
@@ -37,6 +39,9 @@ use std::{fmt, sync::Arc, task::Poll};
 
 pub use stream::{Packet, State, Stream};
 
+/// Next connection identifier, used for debug logging.
+static NEXT_ID: AtomicU32 = AtomicU32::new(1);
+
 /// How the connection is used.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Mode {
@@ -48,14 +53,14 @@ pub enum Mode {
 
 /// The connection identifier.
 ///
-/// Randomly generated, this is mainly intended to improve log output.
+/// Sequentially generated, this is mainly intended to improve log output.
 #[derive(Clone, Copy)]
 pub(crate) struct Id(u32);
 
 impl Id {
-    /// Create a random connection ID.
-    pub(crate) fn random() -> Self {
-        Id(rand::random())
+    /// Create a new connection ID.
+    pub(crate) fn next() -> Self {
+        Id(NEXT_ID.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -351,7 +356,7 @@ impl<T> fmt::Display for Active<T> {
 impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     /// Create a new `Connection` from the given I/O resource.
     fn new(socket: T, cfg: Config, mode: Mode) -> Self {
-        let id = Id::random();
+        let id = Id::next();
         log::debug!("new connection: {id} ({mode:?})");
         let socket = frame::Io::new(id, socket).fuse();
         Active {
@@ -784,10 +789,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Active<T> {
     fn on_ping(&mut self, frame: &Frame<Ping>) -> Action {
         let stream_id = frame.header().stream_id();
         if frame.header().flags().contains(header::ACK) {
-            return self.rtt.handle_pong(frame.nonce());
+            return self.rtt.handle_pong(frame.id());
         }
         if stream_id == CONNECTION_ID || self.streams.contains_key(&stream_id) {
-            let mut hdr = Header::ping(frame.header().nonce());
+            let mut hdr = Header::ping(frame.header().id());
             hdr.ack();
             return Action::Ping(Frame::new(hdr));
         }

--- a/yamux/src/connection/rtt.rs
+++ b/yamux/src/connection/rtt.rs
@@ -10,7 +10,10 @@
 
 //! Connection round-trip time measurement
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
 
 use parking_lot::Mutex;
 use web_time::{Duration, Instant};
@@ -21,20 +24,27 @@ use crate::frame::{header::Ping, Frame};
 const PING_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Debug)]
-pub(crate) struct Rtt(Arc<Mutex<RttInner>>);
+pub(crate) struct Rtt {
+    inner: Arc<Mutex<RttInner>>,
+    /// Next ping identifier, used for matching pongs.
+    next_id: Arc<AtomicU32>,
+}
 
 impl Rtt {
     pub(crate) fn new() -> Self {
-        Self(Arc::new(Mutex::new(RttInner {
-            rtt: None,
-            state: RttState::Waiting {
-                next: Instant::now(),
-            },
-        })))
+        Self {
+            inner: Arc::new(Mutex::new(RttInner {
+                rtt: None,
+                state: RttState::Waiting {
+                    next: Instant::now(),
+                },
+            })),
+            next_id: Arc::new(AtomicU32::new(0)),
+        }
     }
 
     pub(crate) fn next_ping(&mut self) -> Option<Frame<Ping>> {
-        let state = &mut self.0.lock().state;
+        let state = &mut self.inner.lock().state;
 
         match state {
             RttState::AwaitingPong { .. } => return None,
@@ -45,34 +55,34 @@ impl Rtt {
             }
         }
 
-        let nonce = rand::random();
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         *state = RttState::AwaitingPong {
             sent_at: Instant::now(),
-            nonce,
+            id,
         };
-        log::debug!("sending ping {nonce}");
-        Some(Frame::ping(nonce))
+        log::debug!("sending ping {id}");
+        Some(Frame::ping(id))
     }
 
-    pub(crate) fn handle_pong(&mut self, received_nonce: u32) -> Action {
-        let inner = &mut self.0.lock();
+    pub(crate) fn handle_pong(&mut self, received_id: u32) -> Action {
+        let inner = &mut self.inner.lock();
 
-        let (sent_at, expected_nonce) = match inner.state {
+        let (sent_at, expected_id) = match inner.state {
             RttState::Waiting { .. } => {
-                log::error!("received unexpected pong {received_nonce}");
+                log::error!("received unexpected pong {received_id}");
                 return Action::Terminate(Frame::protocol_error());
             }
-            RttState::AwaitingPong { sent_at, nonce } => (sent_at, nonce),
+            RttState::AwaitingPong { sent_at, id } => (sent_at, id),
         };
 
-        if received_nonce != expected_nonce {
-            log::error!("received pong with {received_nonce} but expected {expected_nonce}");
+        if received_id != expected_id {
+            log::error!("received pong with {received_id} but expected {expected_id}");
             return Action::Terminate(Frame::protocol_error());
         }
 
         let rtt = sent_at.elapsed();
         inner.rtt = Some(rtt);
-        log::debug!("received pong {received_nonce}, estimated round-trip-time {rtt:?}");
+        log::debug!("received pong {received_id}, estimated round-trip-time {rtt:?}");
 
         inner.state = RttState::Waiting {
             next: Instant::now() + PING_INTERVAL,
@@ -82,14 +92,17 @@ impl Rtt {
     }
 
     pub(crate) fn get(&self) -> Option<Duration> {
-        self.0.lock().rtt
+        self.inner.lock().rtt
     }
 }
 
 #[cfg(test)]
 impl quickcheck::Arbitrary for Rtt {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        Self(Arc::new(Mutex::new(RttInner::arbitrary(g))))
+        Self {
+            inner: Arc::new(Mutex::new(RttInner::arbitrary(g))),
+            next_id: Arc::new(AtomicU32::new(0)),
+        }
     }
 }
 
@@ -117,7 +130,7 @@ impl quickcheck::Arbitrary for RttInner {
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone))]
 enum RttState {
-    AwaitingPong { sent_at: Instant, nonce: u32 },
+    AwaitingPong { sent_at: Instant, id: u32 },
     Waiting { next: Instant },
 }
 
@@ -127,7 +140,7 @@ impl quickcheck::Arbitrary for RttState {
         if bool::arbitrary(g) {
             RttState::AwaitingPong {
                 sent_at: Instant::now(),
-                nonce: u32::arbitrary(g),
+                id: u32::arbitrary(g),
             }
         } else {
             RttState::Waiting {

--- a/yamux/src/frame.rs
+++ b/yamux/src/frame.rs
@@ -133,8 +133,8 @@ impl Frame<WindowUpdate> {
 }
 
 impl Frame<Ping> {
-    pub fn ping(nonce: u32) -> Self {
-        let mut header = Header::ping(nonce);
+    pub fn ping(id: u32) -> Self {
+        let mut header = Header::ping(id);
         header.syn();
 
         Frame {
@@ -143,8 +143,8 @@ impl Frame<Ping> {
         }
     }
 
-    pub fn nonce(&self) -> u32 {
-        self.header.nonce()
+    pub fn id(&self) -> u32 {
+        self.header.id()
     }
 }
 

--- a/yamux/src/frame/header.rs
+++ b/yamux/src/frame/header.rs
@@ -166,19 +166,19 @@ impl Header<WindowUpdate> {
 
 impl Header<Ping> {
     /// Create a new ping frame header.
-    pub fn ping(nonce: u32) -> Self {
+    pub fn ping(id: u32) -> Self {
         Header {
             version: Version(0),
             tag: Tag::Ping,
             flags: Flags(0),
             stream_id: StreamId(0),
-            length: Len(nonce),
+            length: Len(id),
             _marker: std::marker::PhantomData,
         }
     }
 
-    /// The nonce of this ping.
-    pub fn nonce(&self) -> u32 {
+    /// The id of this ping.
+    pub fn id(&self) -> u32 {
         self.length.0
     }
 }

--- a/yamux/src/frame/io.rs
+++ b/yamux/src/frame/io.rs
@@ -384,7 +384,7 @@ mod tests {
     fn encode_decode_identity() {
         fn property(f: Frame<()>) -> bool {
             futures::executor::block_on(async move {
-                let id = crate::connection::Id::random();
+                let id = crate::connection::Id::next();
                 let mut io = Io::new(id, futures::io::Cursor::new(Vec::new()));
                 if io.send(f.clone()).await.is_err() {
                     return false;


### PR DESCRIPTION
Replace the runtime usages of rand::random() with atomic counters. 
The connection identifier was only used for debug logging and had no protocol significance, so a sequential counter from `AtomicU32` should suffice. 

The same applies to the ping identifier, matching the approach used in the Go yamux reference implementation where a sequentially incremented `uint32` under a `mutex` is used, [1](https://github.com/hashicorp/yamux/blob/master/session.go#L333-L338). 

Move `rand` to dev-dependencies, it's now only required in test code to fill frame bodies with random bytes.